### PR TITLE
chore: add link to new repo.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 | :exclamation: WARNING: This workshop is out of date and uses an earlier beta version of the Pact .NET project. It is not currently recommended for use |
-| See https://github.com/pact-foundation/pact-workshop-dotnet for an up-to-date version |
 |-----------------------------------------|
+
+> See https://github.com/pact-foundation/pact-workshop-dotnet for an up-to-date version
 
 
 # Pact .NET Core Workshop

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 | :exclamation: WARNING: This workshop is out of date and uses an earlier beta version of the Pact .NET project. It is not currently recommended for use |
+| See https://github.com/pact-foundation/pact-workshop-dotnet for an up-to-date version |
 |-----------------------------------------|
+
 
 # Pact .NET Core Workshop
 


### PR DESCRIPTION
fixes #6 

We have now applied the changes to a hard fork 

https://github.com/pact-foundation/pact-workshop-dotnet

and will update the documentation in other places to reflect.

It would be worth marking this repo as archived once this is done (and all existing PR's / issues are closed off)

